### PR TITLE
fix: send the version metadata in lifespan

### DIFF
--- a/starlette_testclient/_testclient.py
+++ b/starlette_testclient/_testclient.py
@@ -544,7 +544,7 @@ class TestClient(requests.Session):
         self.exit_stack.close()
 
     async def lifespan(self) -> None:
-        scope = {"type": "lifespan"}
+        scope = {"type": "lifespan", "asgi": {"version": "3.0"}}
         try:
             await self.app(scope, self.stream_receive.receive, self.stream_send.send)
         finally:


### PR DESCRIPTION
From the spec

> The key scope["asgi"] will also be present as a dictionary containing a scope["asgi"]["version"] key that corresponds to the ASGI version the server implements. If missing, the version should default to "2.0".